### PR TITLE
Update TotemTimers.lua

### DIFF
--- a/TotemTimers.lua
+++ b/TotemTimers.lua
@@ -373,7 +373,7 @@ function TotemTimers.UpdateMacro()
         local timers = XiTimers.timers
         local order = TotemTimers.ActiveProfile.Order
         for i=1,4 do
-        local timer = timers[order[i]]
+        local timer = timers[i]
             if timer.active then
                 local spell = timer.button:GetAttribute("*spell1")
                 if spell then


### PR DESCRIPTION
Fixes macro build function so it properly builds the macro based on the selected totem order. Timers is already sorted according to the chosen Order, so using TotemTimers.ActiveProfile.Order messes up the order further.