### PR TITLE
[Mists Classic] 5.5.4 compatibility and bugfixes

### DIFF
--- a/GUI/General.lua
+++ b/GUI/General.lua
@@ -309,14 +309,12 @@ function TotemTimers.HookGUIFrame(frame, categoryID)
                 InterfaceOptionsFrame:Hide()
             end
         end
-        if WOW_PROJECT_ID ~= WOW_PROJECT_CATACLYSM_CLASSIC then
-            TotemTimers.LastGUIPanel = Settings and categoryID or frame
-        end
+        TotemTimers.LastGUIPanel = Settings and frame.name or frame
     end)
 
     frame:RegisterEvent("PLAYER_REGEN_DISABLED")
 end
 
 TotemTimers.HookGUIFrame(frame, categoryID)
-TotemTimers.LastGUIPanel = Settings and "TotemTimers" or frame
+TotemTimers.LastGUIPanel = Settings and frame.name or frame
 

--- a/GUI/Sets.lua
+++ b/GUI/Sets.lua
@@ -41,7 +41,16 @@ frame:HookScript("OnShow", function(self)
             local totems = {}
             for element = 1,4 do
                 if set[element] then
-                    totems[element] = TotemTimers.ElementColors[element]:WrapTextInColorCode(SpellNames[set[element]])
+                    if not SpellNames[set[element]] then
+                        print("TT: missing name for spell "..set[element])
+                        print("    totem might no longer exist, delete/remake the set")
+                    end
+                    if not TotemTimers.ElementColors[element] then
+                        print("TT: missing color for element "..element)
+                    end
+                    if TotemTimers.ElementColors[element] then
+                        totems[element] = TotemTimers.ElementColors[element]:WrapTextInColorCode(SpellNames[set[element]] or tostring(set[element]))
+                    end
                 end
             end
 
@@ -59,7 +68,11 @@ frame:HookScript("OnShow", function(self)
                     set.name = value
 
                     ACR:NotifyChange("TotemTimers")
-                    InterfaceOptionsFrame_OpenToCategory(frame)
+                    if Settings and Settings.OpenToCategory then
+                        Settings.OpenToCategory(frame.name)
+                    elseif InterfaceOptionsFrame_OpenToCategory then
+                        InterfaceOptionsFrame_OpenToCategory(frame)
+                    end
                 end,
             })
 
@@ -84,6 +97,10 @@ StaticPopupDialogs["TOTEMTIMERS_DELETESET"].OnAccept = function(self, nr)
     deleteOnAccept(self, nr)
     if frame:IsVisible() then
         ACR:NotifyChange("TotemTimers")
-        InterfaceOptionsFrame_OpenToCategory(frame)
+        if Settings and Settings.OpenToCategory then
+            Settings.OpenToCategory(frame.name)
+        elseif InterfaceOptionsFrame_OpenToCategory then
+            InterfaceOptionsFrame_OpenToCategory(frame)
+        end
     end
 end

--- a/TTActionBars.lua
+++ b/TTActionBars.lua
@@ -64,7 +64,7 @@ function TTActionBars:new(numbuttons, parent, secondanchor, directionanchor, bar
         b.icon:Show()
 
 		b:SetAttribute("_childupdate-show", [[ if self:GetAttribute("alwaysshow") or self:GetAttribute("inactive") then return end
-                                               if message then
+                                               if message == true then
                                                    self:Show()
                                                else
                                                    self:Hide()
@@ -87,7 +87,7 @@ function TTActionBars:new(numbuttons, parent, secondanchor, directionanchor, bar
         parent:SetAttribute("_onenter", [[ if self:GetAttribute("OpenMenu") == "mouseover" then
                                                   self:ChildUpdate("show", true)
                                               end ]])
-
+        -- mists 5.5.4 IsUnderMouse seems to ignore recursive param
         parent:SetAttribute("_onleave", [[
             if not self:IsUnderMouse(true) then
                 owner:ChildUpdate("show", false)
@@ -99,7 +99,7 @@ function TTActionBars:new(numbuttons, parent, secondanchor, directionanchor, bar
                                                        control:ChildUpdate("show", false)
                                                    end
                                                  ]])
-
+        b:SetAttribute("_onenter", [[ self:GetParent():ChildUpdate("show", true)]]) -- mists 5.5.4 need this because IsUnderMouse(recursive) is broken
         b:SetAttribute("_onhide", [[self:ClearBindings() self:GetParent():SetAttribute("open", false)]])
         b:SetAttribute("_onleave", [[ if not self:GetParent():IsUnderMouse(true) then self:GetParent():ChildUpdate("show", false) end]])
         b.OnShow = function(self) end -- override if button should do additional stuff on show

--- a/TotemTimers_Mists.toc
+++ b/TotemTimers_Mists.toc
@@ -1,4 +1,4 @@
-## Interface: 50500, 50501
+## Interface: 50504
 ## Title: TotemTimers
 ## Author:  Xianghar
 ## Version: @project-version@


### PR DESCRIPTION
butfix: 5.5.4 broke RE:IsUnderMouse, workaround for mouseover flyouts breaking
bugfix: /totemtimers not opening blizzard settings, sets option subcategory broken
feature: add a notification to the user when their sets contain obsolete spells
maintenance: metadata update, compatible with mists 5.5.4